### PR TITLE
change "漢語" to "華語"

### DIFF
--- a/scripts/pre-build/generateSession.ts
+++ b/scripts/pre-build/generateSession.ts
@@ -110,7 +110,7 @@ function genResult (talks, rooms, speakers) {
       room: s.slot.room?.en || s.slot.room?.['zh-tw'],
       start: s.slot.start,
       end: s.slot.end,
-      language: s.content_locale === 'zh-tw' ? '漢語' : 'English',
+      language: s.content_locale === 'zh-tw' ? '華語' : 'English',
       zh: {
         title: s.title,
         description: getAnswer(s, SESSION_ZH_DESCRIPTION_ID, s.abstract || '')


### PR DESCRIPTION
本 PR 將對語言的稱呼從「漢語」改為「華語」。

## 為什麼要做這個改變？

首先，「漢語」一詞指的可能是多個彼此不互通的大語種 [[1]](https://zh.wikipedia.org/zh-tw/汉语#概論)，又或者是指「現代標準漢語」。現代標準漢語在各地有不同的稱呼，如「普通話」、「國語」、「華語」等[[2]](https://zh.wikipedia.org/zh-tw/現代標準漢語#名稱)。

如果此處的「漢語」指的是前者的話，建議應更進一步區分出各個語言，如再區分為「華語」、「臺語」，語言代碼或許可以參考維基百科，對應為 `zh-tw` 與 `zh-min-nan`。（但 `zh-min-nan` 沒辦法區分出臺語與其他「閩南語」的差別 [[3]](https://github.com/KIRINPUTRA/reclassifying-ISO-639-3-nan/blob/4e05b2924f92219f86f58506b57161112e0122d3/Reclassifying_ISO_639-3_%5Bnan%5D__An_Empirical_Approach_to_Mutual_Intelligibility_and_Ethnolinguistic_Distinctions.pdf)，而且 ISO 15897 代表的應是書面語文，而非口語，建議應該用 ISO 639-3。但這個應屬於 Pretalx 那邊要改的。）
若指後者，其在臺灣的較常用的稱呼為「國語」或「華語」，使用「漢語」的例子較不常見。由於臺灣特殊的環境，使用「國語」一詞在現代社會已經不合時宜。隨著《國家語言發展法》的通過，今年，文化部也將「金曲獎」中原先的「國語」相關獎項的稱呼改為「華語」[[4]](https://www.cna.com.tw/news/acul/202101160163.aspx)。
